### PR TITLE
Fix DBus linking target name

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,7 +44,7 @@ target_include_directories(${APP_NAME}
     PRIVATE ${ZBAR_INCLUDE_DIRS})
 
 if (UNIX AND NOT APPLE)
-    target_link_libraries(${APP PRIVATE Qt6::DBus
+    target_link_libraries(${APP_NAME} PRIVATE Qt6::DBus)
 endif()
 
 install(TARGETS ${APP_NAME}


### PR DESCRIPTION
## Summary
- correct the Unix-specific DBus link to use the proper executable target name
- close the target_link_libraries call correctly for Qt6::DBus

## Testing
- cmake -B build -S . && cmake --build build *(fails: Qt6 package not found in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69263669290c8329986de8c484229ed5)