### PR TITLE
Add Debian setup and build script

### DIFF
--- a/scripts/setup_debian_build.sh
+++ b/scripts/setup_debian_build.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script bootstraps a fresh Debian system with all dependencies
+# required to build the Shadowsocks GUI, then clones the repository and
+# performs a Release build. It is intended for non-interactive use on
+# a clean VM.
+
+REPO_URL="${REPO_URL:-https://github.com/juriyivanov/shadowsocks-gui.git}"
+CHECKOUT_DIR="${CHECKOUT_DIR:-$HOME/shadowsocks-gui}"
+BUILD_TYPE="${BUILD_TYPE:-Release}"
+
+if [[ $(id -u) -ne 0 ]]; then
+    SUDO="sudo"
+else
+    SUDO=""
+fi
+
+info() {
+    printf '\033[1;34m[INFO]\033[0m %s\n' "$*"
+}
+
+info "Updating apt indices..."
+$SUDO apt-get update
+
+info "Installing build dependencies..."
+$SUDO apt-get install -y \
+    git build-essential cmake pkg-config \
+    qt6-base-dev qt6-base-dev-tools qt6-tools-dev qt6-tools-dev-tools libqt6svg6-dev \
+    libqrencode-dev libzbar-dev libqtshadowsocks-dev
+
+if [[ ! -d "$CHECKOUT_DIR" ]]; then
+    info "Cloning repository into $CHECKOUT_DIR"
+    git clone "$REPO_URL" "$CHECKOUT_DIR"
+else
+    info "Repository already exists at $CHECKOUT_DIR; pulling latest changes"
+    git -C "$CHECKOUT_DIR" pull --ff-only
+fi
+
+cd "$CHECKOUT_DIR"
+
+info "Configuring CMake (build type: $BUILD_TYPE)"
+cmake -B build -S . -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
+
+info "Building project"
+cmake --build build -j"$(nproc)"
+
+info "Build completed successfully"


### PR DESCRIPTION
## Summary
- add a Debian automation script that installs build prerequisites, clones the repository, and performs a Release build
- make the script configurable through environment variables for repo URL, checkout directory, and build type

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69263b91e68c8329a38c5166faa15b07)