### PR TITLE
Add Debian bootstrap build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ Originally forked from `shadowsocks-qt5`, this project now targets **Qt 6**, C+
 * Auto‑start on login (optional)
 * i18n with **gettext / Qt Linguist** – contributions welcome!
 
+На чистой Debian-машине эти шаги можно автоматизировать с помощью `scripts/bootstrap-debian.sh`,
+который подтянет системные зависимости, соберёт QtShadowsocks и выполнит сборку проекта:
+
+```bash
+$ ./scripts/bootstrap-debian.sh
+```
+
 ---
 
 ## 🛠️ Build instructions

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Originally forked from `shadowsocks-qt5`, this project now targets **Qt 6**, C+
 * i18n with **gettext / Qt Linguist** – contributions welcome!
 
 На чистой Debian-машине эти шаги можно автоматизировать с помощью `scripts/bootstrap-debian.sh`,
-который подтянет системные зависимости (включая Qt 5 для сборки QtShadowsocks), соберёт QtShadowsocks
-и выполнит сборку проекта:
+который подтянет системные зависимости (включая qmake/Qt 5 для сборки QtShadowsocks и выставит `Qt5_DIR`),
+соберёт QtShadowsocks и выполнит сборку проекта:
 
 ```bash
 $ ./scripts/bootstrap-debian.sh

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Originally forked from `shadowsocks-qt5`, this project now targets **Qt 6**, C+
 * i18n with **gettext / Qt Linguist** – contributions welcome!
 
 На чистой Debian-машине эти шаги можно автоматизировать с помощью `scripts/bootstrap-debian.sh`,
-который подтянет системные зависимости, соберёт QtShadowsocks и выполнит сборку проекта:
+который подтянет системные зависимости (включая Qt 5 для сборки QtShadowsocks), соберёт QtShadowsocks
+и выполнит сборку проекта:
 
 ```bash
 $ ./scripts/bootstrap-debian.sh

--- a/scripts/bootstrap-debian.sh
+++ b/scripts/bootstrap-debian.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script provisions a fresh Debian machine with all dependencies
+# required to build the Shadowsocks GUI application. It installs the
+# build toolchain, clones a QtShadowsocks fork and the application
+# repository, and then performs a Release build.
+
+# Configuration (can be overridden via environment variables).
+# QSS_REPO should point to a Qt 6 compatible QtShadowsocks fork.
+WORKDIR=${WORKDIR:-$PWD/shadowsocks-gui}
+SHADOWSOCKS_GUI_REPO=${SHADOWSOCKS_GUI_REPO:-https://github.com/juriyivanov/shadowsocks-gui.git}
+QSS_REPO=${QSS_REPO:-https://github.com/shadowsocks/libQtShadowsocks.git}
+QSS_BRANCH=${QSS_BRANCH:-master}
+QSS_BUILD_DIR=${QSS_BUILD_DIR:-/tmp/qtshadowsocks-build}
+
+# Use sudo only when necessary
+if [ "${EUID}" -ne 0 ]; then
+    SUDO=sudo
+else
+    SUDO=""
+fi
+
+info() { printf "\n[%s] %s\n" "$(date -Iseconds)" "$*"; }
+
+info "Updating APT index and installing build dependencies"
+$SUDO env DEBIAN_FRONTEND=noninteractive apt-get update
+$SUDO env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    git ca-certificates build-essential cmake ninja-build pkg-config \
+    qt6-base-dev qt6-base-dev-tools qt6-tools-dev qt6-tools-dev-tools \
+    libqrencode-dev libzbar-dev libbotan-2-dev
+
+info "Cloning QtShadowsocks from ${QSS_REPO} (branch: ${QSS_BRANCH})"
+rm -rf "${QSS_BUILD_DIR}"
+git clone --depth=1 --branch "${QSS_BRANCH}" "${QSS_REPO}" "${QSS_BUILD_DIR}"
+
+info "Configuring and building QtShadowsocks"
+cmake -S "${QSS_BUILD_DIR}" -B "${QSS_BUILD_DIR}/build" \
+    -G Ninja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=/usr/local
+cmake --build "${QSS_BUILD_DIR}/build" --parallel
+$SUDO cmake --install "${QSS_BUILD_DIR}/build"
+
+info "Cloning Shadowsocks GUI into ${WORKDIR}"
+rm -rf "${WORKDIR}"
+git clone "${SHADOWSOCKS_GUI_REPO}" "${WORKDIR}"
+
+info "Configuring and building Shadowsocks GUI"
+cmake -S "${WORKDIR}" -B "${WORKDIR}/build" -G Ninja -DCMAKE_BUILD_TYPE=Release
+cmake --build "${WORKDIR}/build" --parallel
+
+info "Done. Binaries are in ${WORKDIR}/build"

--- a/scripts/bootstrap-debian.sh
+++ b/scripts/bootstrap-debian.sh
@@ -28,6 +28,7 @@ $SUDO env DEBIAN_FRONTEND=noninteractive apt-get update
 $SUDO env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     git ca-certificates build-essential cmake ninja-build pkg-config \
     qt6-base-dev qt6-base-dev-tools qt6-tools-dev qt6-tools-dev-tools \
+    qtbase5-dev qttools5-dev qttools5-dev-tools \
     libqrencode-dev libzbar-dev libbotan-2-dev
 
 info "Cloning QtShadowsocks from ${QSS_REPO} (branch: ${QSS_BRANCH})"

--- a/scripts/bootstrap-debian.sh
+++ b/scripts/bootstrap-debian.sh
@@ -28,7 +28,7 @@ $SUDO env DEBIAN_FRONTEND=noninteractive apt-get update
 $SUDO env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     git ca-certificates build-essential cmake ninja-build pkg-config \
     qt6-base-dev qt6-base-dev-tools qt6-tools-dev qt6-tools-dev-tools \
-    qtbase5-dev qttools5-dev qttools5-dev-tools \
+    qtbase5-dev qtbase5-dev-tools qttools5-dev qttools5-dev-tools qt5-qmake \
     libqrencode-dev libzbar-dev libbotan-2-dev
 
 info "Cloning QtShadowsocks from ${QSS_REPO} (branch: ${QSS_BRANCH})"
@@ -39,7 +39,8 @@ info "Configuring and building QtShadowsocks"
 cmake -S "${QSS_BUILD_DIR}" -B "${QSS_BUILD_DIR}/build" \
     -G Ninja \
     -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_INSTALL_PREFIX=/usr/local
+    -DCMAKE_INSTALL_PREFIX=/usr/local \
+    -DQt5_DIR=/usr/lib/x86_64-linux-gnu/cmake/Qt5
 cmake --build "${QSS_BUILD_DIR}/build" --parallel
 $SUDO cmake --install "${QSS_BUILD_DIR}/build"
 


### PR DESCRIPTION
## Summary
- add a Debian bootstrap script that installs prerequisites, builds QtShadowsocks, and builds the app
- document the script alongside the existing build instructions

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69263e8af5ac8329925baff51617ac62)