### PR TITLE
Improve Qt6 dependency guidance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Find Qt 6 components
-find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets Network DBus)
+find_package(Qt6 COMPONENTS Core Gui Widgets Network DBus QUIET)
+if(NOT Qt6_FOUND)
+    message(FATAL_ERROR "Qt 6 (Core/Gui/Widgets/Network/DBus) was not found. Install the Qt 6 development files and set Qt6_DIR or CMAKE_PREFIX_PATH if they are not in the default location.")
+endif()
 
 find_package(PkgConfig REQUIRED)
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ Originally forked from `shadowsocks-qt5`, this project now targets **Qt 6**, C+
 | libqrencode   | any             | QR code generation                       |
 | zbar          | any             | QR code scanning                         |
 
+On Debian/Ubuntu, the Qt 6 development files live in `qt6-base-dev` and the
+pkg-config helpers ship with `qt6-base-dev-tools`. If CMake cannot locate Qt 6
+(e.g. `Qt6Config.cmake` not found), install these packages and, if necessary,
+export `CMAKE_PREFIX_PATH=/usr/lib/qt6/cmake` or point `Qt6_DIR` at the Qt 6
+`lib/cmake/Qt6` directory.
+
 ```bash
 # Clone
 $ git clone https://github.com/juriyivanov/shadowsocks-gui.git


### PR DESCRIPTION
## Summary
- add a clearer CMake fatal error when Qt 6 is not detected
- document required Qt 6 Debian/Ubuntu packages and how to set Qt6_DIR/CMAKE_PREFIX_PATH

## Testing
- not run (dependency setup not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926ee604ef88329b3bf19af08bd2fb0)