### PR TITLE
Add Qt 5 fallback and clarify dependency notes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,30 +12,51 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-# Find Qt 6 components
-find_package(Qt6 COMPONENTS Core Gui Widgets Network DBus QUIET)
-if(NOT Qt6_FOUND)
-    message(FATAL_ERROR "Qt 6 (Core/Gui/Widgets/Network/DBus) was not found. Install the Qt 6 development files and set Qt6_DIR or CMAKE_PREFIX_PATH if they are not in the default location.")
+set(_qt_components Core Gui Widgets Network)
+if(UNIX AND NOT APPLE)
+    list(APPEND _qt_components DBus)
+endif()
+
+# Prefer Qt 6 but fall back to a Qt 5 toolchain if available.
+find_package(Qt6 COMPONENTS ${_qt_components} QUIET)
+if(Qt6_FOUND)
+    set(QT_PACKAGE_PREFIX Qt6)
+else()
+    find_package(Qt5 COMPONENTS ${_qt_components} QUIET)
+    if(NOT Qt5_FOUND)
+        set(_missing_components "Core/Gui/Widgets/Network")
+        if(UNIX AND NOT APPLE)
+            string(APPEND _missing_components "/DBus")
+        endif()
+        message(FATAL_ERROR "Neither Qt 6 nor Qt 5 (${_missing_components}) was found. Install the matching Qt development files and set Qt6_DIR/Qt5_DIR or CMAKE_PREFIX_PATH if they are not in the default location.")
+    endif()
+    set(QT_PACKAGE_PREFIX Qt5)
 endif()
 
 find_package(PkgConfig REQUIRED)
 
 # Prefer the Qt 6 pkg-config name used by recent libQtShadowsocks releases
-pkg_check_modules(QSS_QT6 QtShadowsocks-qt6>=2.0.0)
-if(QSS_QT6_FOUND)
-    set(_QSS_PREFIX QSS_QT6)
-else()
-    # Fallback to the legacy name but keep the Qt 6 requirement explicit so
-    # a Qt 5 build of the library is rejected early.
-    pkg_check_modules(QSS_QTLEGACY QtShadowsocks>=2.0.0)
-    if(NOT QSS_QTLEGACY_FOUND)
-        message(FATAL_ERROR "libQtShadowsocks (Qt 6 build) was not found. Install a Qt 6 build of the library and ensure its pkg-config file is discoverable.")
+if(QT_PACKAGE_PREFIX STREQUAL "Qt6")
+    pkg_check_modules(QSS_QT QtShadowsocks-qt6>=2.0.0)
+    if(NOT QSS_QT_FOUND)
+        # Fallback to the legacy name but keep the Qt 6 requirement explicit so
+        # a Qt 5 build of the library is rejected early.
+        pkg_check_modules(QSS_QT QtShadowsocks>=2.0.0)
+        if(NOT QSS_QT_FOUND)
+            message(FATAL_ERROR "libQtShadowsocks (Qt 6 build) was not found. Install a Qt 6 build of the library and ensure its pkg-config file is discoverable.")
+        endif()
     endif()
-    set(_QSS_PREFIX QSS_QTLEGACY)
+else()
+    # Qt 5 builds are only used when Qt 6 is unavailable; accept either the qt5
+    # or legacy pkg-config name.
+    pkg_check_modules(QSS_QT QtShadowsocks-qt5 QtShadowsocks)
+    if(NOT QSS_QT_FOUND)
+        message(FATAL_ERROR "libQtShadowsocks (Qt 5 build) was not found. Install a Qt 5 build of the library and ensure its pkg-config file is discoverable.")
+    endif()
 endif()
 
 foreach(_field INCLUDE_DIRS LIBRARIES LIBDIR LIBRARY_DIRS)
-    set(QSS_${_field} ${${_QSS_PREFIX}_${_field}})
+    set(QSS_${_field} ${QSS_QT_${_field}})
 endforeach()
 
 find_library(QSS_LIBRARY_VAR

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Shadowsocks GUI (Qt 6)
 
 A **cross‑platform**, actively‑maintained graphical client for the [Shadowsocks](https://shadowsocks.org) proxy.
-Originally forked from `shadowsocks-qt5`, this project now targets **Qt 6**, C++17 (soon C++20), and brings numerous UX, security and build‑system improvements.
+Originally forked from `shadowsocks-qt5`, this project now targets **Qt 6**, C++17 (soon C++20), and brings numerous UX, security and build‑system improvements. A Qt 5 toolchain can still be used if Qt 6 is unavailable, but Qt 6 remains the preferred and better‑tested option.
 
 ---
 
@@ -11,11 +11,7 @@ Originally forked from `shadowsocks-qt5`, this project now targets **Qt 6**, C+
 * Multiple server profiles with tags & search
 | QtShadowsocks |  ≥ 2.0.0        | Provides core controller library (**build against Qt 6; see note below**) |
 
-> **QtShadowsocks note:** the GUI depends on a **Qt 6** build of `libQtShadowsocks` (v2.0.0+).
-> Building the upstream `master` branch will try to find **Qt 5** and fail with errors such as
-> `Qt5::Core not found`. Use a Qt 6–enabled release/branch of the library instead (for example,
-> the `qt6` branch in `shadowsocks/libQtShadowsocks`) and install it before configuring this
-> project.
+> **QtShadowsocks note:** the GUI prefers a **Qt 6** build of `libQtShadowsocks` (v2.0.0+). If you only have Qt 5 installed, the CMake configuration will fall back to a Qt 5 build of the library. To avoid errors such as `Qt5::Core not found`, make sure the Qt version of your installed `libQtShadowsocks` matches the Qt toolchain discovered by CMake (for example, use the `qt6` branch in `shadowsocks/libQtShadowsocks` when building with Qt 6).
 
 * Built‑in QR scanner / screenshot recogniser
 * Latency tester, traffic stats & data‑cap reset reminders
@@ -54,7 +50,9 @@ On Debian/Ubuntu, the Qt 6 development files live in `qt6-base-dev` and the
 pkg-config helpers ship with `qt6-base-dev-tools`. If CMake cannot locate Qt 6
 (e.g. `Qt6Config.cmake` not found), install these packages and, if necessary,
 export `CMAKE_PREFIX_PATH=/usr/lib/qt6/cmake` or point `Qt6_DIR` at the Qt 6
-`lib/cmake/Qt6` directory.
+`lib/cmake/Qt6` directory. When falling back to Qt 5, install `qtbase5-dev`
+and set `Qt5_DIR` or `CMAKE_PREFIX_PATH` accordingly so that CMake can find the
+Qt 5 configuration files.
 
 ```bash
 # Clone

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,10 +31,10 @@ endif()
 add_executable(${APP_NAME} WIN32 ${SOURCE})
 
 target_link_libraries(${APP_NAME}
-    PUBLIC Qt6::Core
-    PUBLIC Qt6::Gui
-    PUBLIC Qt6::Widgets
-    PUBLIC Qt6::Network
+    PUBLIC ${QT_PACKAGE_PREFIX}::Core
+    PUBLIC ${QT_PACKAGE_PREFIX}::Gui
+    PUBLIC ${QT_PACKAGE_PREFIX}::Widgets
+    PUBLIC ${QT_PACKAGE_PREFIX}::Network
     PRIVATE ${QSS_LIBRARY_VAR}
     PRIVATE ${QRENCODE_LIBRARY_VAR}
     PRIVATE ${ZBAR_LIBRARY_VAR})
@@ -44,7 +44,7 @@ target_include_directories(${APP_NAME}
     PRIVATE ${ZBAR_INCLUDE_DIRS})
 
 if (UNIX AND NOT APPLE)
-    target_link_libraries(${APP_NAME} PRIVATE Qt6::DBus)
+    target_link_libraries(${APP_NAME} PRIVATE ${QT_PACKAGE_PREFIX}::DBus)
 endif()
 
 install(TARGETS ${APP_NAME}


### PR DESCRIPTION
## Summary
- allow building with either Qt 6 or Qt 5 by detecting available toolchains and matching libQtShadowsocks
- link application targets against the detected Qt namespace
- document Qt 5 fallback requirements and matching QtShadowsocks guidance

## Testing
- cmake -S . -B build (fails: Qt development packages not installed in CI environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69270122f0cc8329b09107a741d80120)